### PR TITLE
アイコン画像投稿機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,3 +70,7 @@ gem 'momentjs-rails'
 gem 'jquery-turbolinks'
 
 gem 'kaminari'
+
+gem 'carrierwave'
+
+gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,10 @@ GEM
       momentjs-rails (~> 2.10, >= 2.10.5)
     builder (3.2.3)
     byebug (10.0.2)
+    carrierwave (1.2.3)
+      activemodel (>= 4.0.0)
+      activesupport (>= 4.0.0)
+      mime-types (>= 1.16)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -125,6 +129,10 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.9.2)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
+    mini_magick (4.9.2)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -244,6 +252,7 @@ DEPENDENCIES
   bootstrap (~> 4.1.3)
   bootstrap4-datetime-picker-rails
   byebug
+  carrierwave
   coffee-rails (~> 4.2)
   devise
   erb2haml
@@ -254,6 +263,7 @@ DEPENDENCIES
   jquery-turbolinks
   kaminari
   listen (~> 3.0.5)
+  mini_magick
   momentjs-rails
   mysql2 (>= 0.3.18, < 0.6.0)
   pry-rails

--- a/app/assets/stylesheets/modules/_header.scss
+++ b/app/assets/stylesheets/modules/_header.scss
@@ -117,6 +117,18 @@
   }
 }
 
+.user_image{
+  width: 55px;
+  height: 55px;
+  overflow: hidden;
+  float: left;
+  margin-right: 10px;
+  border-radius: 10%;
+  img {
+    height: 55px;
+  }
+}
+
 
 .nav-menu{
   display: block;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,13 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  # def configure_permitted_parameters
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+  # end
+
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up) { |u| u.permit(:username, :email, :password, :password_confirmation, :remember_me, :avatar, :avatar_cache, :remove_avatar) }
+    devise_parameter_sanitizer.permit(:account_update) { |u| u.permit(:username, :email, :password, :password_confirmation, :current_password, :avatar, :avatar_cache, :remove_avatar) }
   end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,14 @@
 class User < ApplicationRecord
+  mount_uploader :avatar, AvatarUploader
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  attr_accessible :email, :password, :remember_me, :avatar, :avatar_cache, :remove_avatar
+
+  validates_presence_of   :avatar
+  validates_integrity_of  :avatar
+  validates_processing_of :avatar
+
   has_many    :events
   has_many    :events, through: :attend_statuses
   has_many    :attend_statuses

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  attr_accessible :email, :password, :remember_me, :avatar, :avatar_cache, :remove_avatar
+  # attr_accessible :email, :password, :remember_me, :avatar, :avatar_cache, :remove_avatar
 
   validates_presence_of   :avatar
   validates_integrity_of  :avatar

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -1,0 +1,47 @@
+class AvatarUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -4,13 +4,12 @@
   .container.max-w.mb-2
     .row
       .col-12
-        = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+        = form_for(resource, as: resource_name, url: registration_path(resource_name), html: {multipart: :true}) do |f|
           = devise_error_messages!
           .field.mb-2
             = f.label :name do
               ユーザー名
             = f.text_field :name, class: "form-control", autofocus: true, autocomplete: "name"
-
           .field.mb-2
             = f.label :email do
               e-mail
@@ -23,6 +22,11 @@
             = f.label :password_confirmation do
               確認用パスワード
             = f.password_field :password_confirmation, class: "form-control", autocomplete: "new-password"
+          .field.mb-2
+            = f.label :avatar do
+              プロフィール画像
+            = f.file_field :avatar
+            = f.hidden_field :avatar_cache
           .actions.mb-2
           = f.submit "登録", class: "btn w-100 participation-btn"
 = render "./shared/footer"

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -3,7 +3,8 @@
     = link_to "event-maneger", root_path, class: "h5 global-menu__title"
     .global-menu__user-info
       - if current_user
-        = current_user.name
+        %span.user_image= image_tag current_user.avatar
+        %span= current_user.name
       - else
         = "ログインはこちら⇨"
 

--- a/db/migrate/20190113030654_add_avatar_to_users.rb
+++ b/db/migrate/20190113030654_add_avatar_to_users.rb
@@ -1,0 +1,5 @@
+class AddAvatarToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :avatar, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190106120451) do
+ActiveRecord::Schema.define(version: 20190113030654) do
 
   create_table "attend_statuses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 20190106120451) do
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
     t.string   "name"
+    t.string   "avatar"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end


### PR DESCRIPTION
#WHAT
ユーザーのアイコン用の画像をアップロードする機能を実装する。

#WHY
アイコン画像を使用することで、ユーザーが個人の特定を行いやすくする為。