### PR TITLE
出欠登録用URLのランダム文字列化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,11 @@ gem 'jbuilder', '~> 2.5'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
+  gem 'pry-byebug'
+  gem 'pry-doc'
   gem 'pry-rails'
+  gem 'pry-stack_explorer'
+  gem 'rb-readline'
 
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,8 @@ GEM
       execjs
     bcrypt (3.1.12)
     bindex (0.5.0)
+    binding_of_caller (0.8.0)
+      debug_inspector (>= 0.0.1)
     bootstrap (4.1.3)
       autoprefixer-rails (>= 6.0.3)
       popper_js (>= 1.12.9, < 2)
@@ -66,6 +68,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.4)
     crass (1.0.4)
+    debug_inspector (0.0.3)
     devise (4.5.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -148,8 +151,17 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    pry-rails (0.3.7)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
+    pry-doc (1.0.0)
+      pry (~> 0.11)
+      yard (~> 0.9.11)
+    pry-rails (0.3.9)
       pry (>= 0.10.4)
+    pry-stack_explorer (0.4.9.3)
+      binding_of_caller (>= 0.7)
+      pry (>= 0.9.11)
     puma (3.12.0)
     rack (2.0.6)
     rack-test (0.6.3)
@@ -181,6 +193,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    rb-readline (0.5.5)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -244,6 +257,7 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    yard (0.9.16)
 
 PLATFORMS
   ruby
@@ -266,9 +280,13 @@ DEPENDENCIES
   mini_magick
   momentjs-rails
   mysql2 (>= 0.3.18, < 0.6.0)
+  pry-byebug
+  pry-doc
   pry-rails
+  pry-stack_explorer
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.1)
+  rb-readline
   rspec
   sass-rails (~> 5.0)
   spring

--- a/app/assets/javascripts/user_avatar.js
+++ b/app/assets/javascripts/user_avatar.js
@@ -1,0 +1,36 @@
+$(document).on("turbolinks:load", function() {
+
+  function previewUserImage(files){
+    resetPreview();
+    for (var i = 0; i < files.length; i++){
+      var file = files[i];
+      if (file.type.indexOf("image") < 0){
+        continue;
+      }
+      var img = document.createElement("img");
+      img.classList.add("previewImage");
+      img.file = file;
+      img.height = 200;
+      document.getElementsByClassName('image-display-area')[0].appendChild(img);
+      var reader = new FileReader();
+      reader.onload = (function(tImg) { return function(e) { tImg.src = e.target.result; }; })(img);
+      reader.readAsDataURL(file);
+    }
+  }
+
+  function resetPreview(){
+    var element = document.getElementsByClassName('image-display-area')[0]
+
+   while (element.firstChild) {
+      element.removeChild(element.firstChild);
+   }
+  }
+
+  $("#user_avatar").on("change", function(e) {
+    var file = e.target.files
+    previewUserImage(file)
+  });
+})
+
+
+

--- a/app/assets/javascripts/users.coffee
+++ b/app/assets/javascripts/users.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/modules/_common.scss
+++ b/app/assets/stylesheets/modules/_common.scss
@@ -29,3 +29,44 @@ a:hover {
 .create-event__title{
   color: $accent-1st-color;
 }
+
+.image-field{
+  & input{
+    display: none;
+  }
+}
+
+.image-display-area{
+  position: relative;
+  overflow: hidden;
+  border-radius: 50%;
+  width: 200px;
+  height: 200px;
+  &:hover{
+    opacity: .6;
+    cursor: pointer;
+  }
+  & img{
+    position: absolute;
+    height: 200px;
+    top: 50%;
+    left: 50%;
+    -webkit-transform: translate(-50%, -50%);
+       -moz-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+         -o-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+  }
+  & i{
+    opacity: .6;
+    z-index: 1;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    -webkit-transform: translate(-50%, -50%);
+       -moz-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+         -o-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
+  }
+}

--- a/app/assets/stylesheets/modules/_event-show.scss
+++ b/app/assets/stylesheets/modules/_event-show.scss
@@ -1,4 +1,13 @@
 //////詳細ページ////////
+
+.card a{
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
 .card-event-detail{
   width: 100%;
   max-width: 400px;
@@ -11,6 +20,24 @@
   word-wrap: break-word;
   background-clip: border-box;
   border-radius: 0.25rem;
+}
+
+.attendance-status{
+    position: absolute;
+    right: 20px;
+    bottom: 20px;
+    color: white;
+    width: 65px;
+    border-radius: 40px;
+    text-align: center;
+}
+
+.status_participation{
+  background-color: $accent-1st-color
+}
+
+.status_absence{
+  background-color: $accent-2nd-color
 }
 
 .author-command{

--- a/app/assets/stylesheets/modules/_header.scss
+++ b/app/assets/stylesheets/modules/_header.scss
@@ -118,14 +118,23 @@
 }
 
 .user_image{
+  position: relative;
   width: 55px;
   height: 55px;
   overflow: hidden;
   float: left;
   margin-right: 10px;
-  border-radius: 10%;
+  border-radius: 30px;
   img {
     height: 55px;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    -webkit-transform: translate(-50%, -50%);
+       -moz-transform: translate(-50%, -50%);
+        -ms-transform: translate(-50%, -50%);
+         -o-transform: translate(-50%, -50%);
+            transform: translate(-50%, -50%);
   }
 }
 

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,8 +7,8 @@ class ApplicationController < ActionController::Base
   # end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up) { |u| u.permit(:username, :email, :password, :password_confirmation, :remember_me, :avatar, :avatar_cache, :remove_avatar) }
-    devise_parameter_sanitizer.permit(:account_update) { |u| u.permit(:username, :email, :password, :password_confirmation, :current_password, :avatar, :avatar_cache, :remove_avatar) }
+    devise_parameter_sanitizer.permit(:sign_up) { |u| u.permit(:name, :email, :password, :password_confirmation, :remember_me, :avatar, :avatar_cache, :remove_avatar) }
+    devise_parameter_sanitizer.permit(:account_update) { |u| u.permit(:name, :email, :password, :password_confirmation, :current_password, :avatar, :avatar_cache, :remove_avatar) }
+    devise_parameter_sanitizer.permit(:edit) { |u| u.permit(:name, :email, :password, :password_confirmation, :current_password, :avatar, :avatar_cache, :remove_avatar) }
   end
-
 end

--- a/app/controllers/attend_statuses_controller.rb
+++ b/app/controllers/attend_statuses_controller.rb
@@ -1,20 +1,24 @@
 class AttendStatusesController < ApplicationController
+  before_action :set_event, only: [:edit]
+
+  def edit
+    @participants = @event.attend_statuses.where('attend = ?', 1).includes(:user).order("updated_at DESC")
+    @absentees = @event.attend_statuses.where('attend = ?', 2).includes(:user).order("updated_at DESC")
+  end
 
   def create
-
-
-
     @attend_status = AttendStatus.find_or_create_by(user_id: current_user.id, event_id: params[:event_id])
-
 
     @attend_status.update(attend: params[:attend])
 
     respond_to do |format|
       format.json { }
       format.html { redirect_to event_path(params[:event_id]) }
-
-
     end
   end
 
+  private
+    def set_event
+      @event = Event.find_by(token: params[:token])
+    end
 end

--- a/app/controllers/attend_statuses_controller.rb
+++ b/app/controllers/attend_statuses_controller.rb
@@ -8,9 +8,7 @@ class AttendStatusesController < ApplicationController
 
   def create
     @attend_status = AttendStatus.find_or_create_by(user_id: current_user.id, event_id: params[:event_id])
-
     @attend_status.update(attend: params[:attend])
-
     respond_to do |format|
       format.json { }
       format.html { redirect_to event_path(params[:event_id]) }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,2 @@
+class UsersController < ApplicationController
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,2 +1,6 @@
 class UsersController < ApplicationController
+  def show
+    @created_events = Event.where('user_id = ?', current_user.id).order("updated_at DESC").page(params[:page]).per(10)
+    @attendance_events = current_user.events.order("updated_at DESC").page(params[:page]).per(10)
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,10 @@
 module ApplicationHelper
+  def attend?(event)
+    status = AttendStatus.where('user_id = ?', current_user.id).where('event_id = ?', event.id)[0].attend
+    if status == 1
+      content_tag :div, "参加", class: "attendance-status status_participation"
+    elsif status == 2
+      content_tag :div, "不参加", class: "attendance-status status_absence"
+    end
+  end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,5 @@
 class Event < ApplicationRecord
-  after_initialize :set_token
+  before_create :set_token
   belongs_to    :user
   has_many      :users, through: :attend_statuses
   has_many      :attend_statuses, dependent: :destroy

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,13 @@
 class Event < ApplicationRecord
+  after_initialize :set_token
   belongs_to    :user
   has_many      :users, through: :attend_statuses
   has_many      :attend_statuses, dependent: :destroy
   validates     :name, presence: true
+
+  private
+  def set_token
+    self.token = SecureRandom.urlsafe_base64(25)
+  end
+
 end

--- a/app/views/attend_statuses/edit.html.haml
+++ b/app/views/attend_statuses/edit.html.haml
@@ -1,0 +1,52 @@
+= render "./shared/header"
+
+%body.main
+  .event.container.max-w
+    .row.mb-2
+      .col-12
+        .card-event-detail.mb-2
+          =render "./events/event", event: @event
+          - if current_user && @event.user_id == current_user.id
+            .author-command
+              = link_to "イベントを編集する", edit_event_path(@event), class: "btn mb-2 accent-1st-color-btn author-command__edit"
+              = link_to "イベントを削除する", "/events/#{@event.id}", method: :delete, class: "btn accent-1st-color-btn author-command__delete"
+    - if current_user
+      .row.mb-2
+        .col-6
+          .w-50.mx-auto
+            = link_to "参加", event_attend_statuses_path(@event, params: {attend: 1}), method: :post, class: "btn w-100 js-participation accent-1st-color-btn", remote: :true
+        .col-6
+          .w-50.mx-auto
+            = link_to "欠席", event_attend_statuses_path(@event, params: {attend: 2}), method: :post, class: "btn w-100 js-absence accent-2nd-color-btn", remote: :true
+
+    .row.mb-2
+      .col-sm-12
+        %h5.text-center.main-color 参加者
+        .participant
+          %ul.participant-list
+            - @participants.each do |participant|
+              %li.border-bottom{id: "user-id_#{participant.user.id}"}
+                = participant.user.name
+
+    .row.mb-5
+      .col-sm-12
+        %h5.text-center.main-color 欠席者
+        .participant
+          %ul.absentee-list
+            - @absentees.each do |absentee|
+              %li.border-bottom{id: "user-id_#{absentee.user.id}"}
+                = absentee.user.name
+
+    - if !current_user
+      .row.mb-2
+        .col-12
+          .w-100.mx-auto
+            .p.text-center.mb-4 出欠を登録するにはログインする必要があります
+            .p.text-center ユーザー登録が完了している方
+            = link_to "ログイン", new_user_session_path, class: "btn w-100 accent-1st-color-btn mb-4"
+            .p.text-center ユーザー登録が済んでいない方
+            = link_to "新規ユーザー登録", new_user_registration_path, class: "btn w-100 accent-1st-color-btn mb-4"
+
+
+
+= render "./shared/footer"

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,36 +1,44 @@
-%h2
-  Edit #{resource_name.to_s.humanize}
-= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-  = devise_error_messages!
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-    %div
-      Currently waiting confirmation for: #{resource.unconfirmed_email}
-  .field
-    = f.label :password
-    %i (leave blank if you don't want to change it)
-    %br/
-    = f.password_field :password, autocomplete: "new-password"
-    - if @minimum_password_length
-      %br/
-      %em
-        = @minimum_password_length
-        characters minimum
-  .field
-    = f.label :password_confirmation
-    %br/
-    = f.password_field :password_confirmation, autocomplete: "new-password"
-  .field
-    = f.label :current_password
-    %i (we need your current password to confirm your changes)
-    %br/
-    = f.password_field :current_password, autocomplete: "current-password"
-  .actions
-    = f.submit "Update"
-%h3 Cancel my account
-%p
-  Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
-= link_to "Back", :back
+= render "./shared/header"
+%body.main
+  %H1.text-center.create-event__title ユーザー情報編集
+  .container.max-w.mb-2
+    .row
+      .col-12
+        = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
+          = devise_error_messages!
+          .field.mb-2.image-field.text-center
+            .text-left プロフィール画像
+            = f.label :avatar, class: "mx-auto" do
+              .image-preview
+                .image-display-area
+                  = fa_icon 'plus-square 4x'
+                  = image_tag current_user.avatar
+
+            = f.file_field :avatar
+            = f.hidden_field :avatar_cache
+          .field.mb-2
+            = f.label :name do
+              ユーザー名
+            = f.text_field :name, class: "form-control", autofocus: true, autocomplete: "name"
+          .field.mb-2
+            = f.label :email do
+              e-mail
+            = f.email_field :email, class: "form-control", autofocus: true, autocomplete: "email"
+          - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+            %div
+              Currently waiting confirmation for: #{resource.unconfirmed_email}
+          .field.mb-2
+            = f.label :password do
+              パスワード (変更しない場合は空白のまま)
+            = f.password_field :password, class: "form-control", autocomplete: "new-password"
+          .field.mb-2
+            = f.label :password_confirmation do
+              確認用パスワード
+            = f.password_field :password_confirmation, class: "form-control", autocomplete: "new-password"
+          .field.mb-2
+            = f.label :current_password do
+              現在のパスワード
+            = f.password_field :current_password, class: "form-control", autocomplete: "current-password"
+          .actions
+            = f.submit "Update", class: "btn w-100 participation-btn"
+= render "./shared/footer"

--- a/app/views/events/create.html.haml
+++ b/app/views/events/create.html.haml
@@ -7,6 +7,6 @@
         .mx-auto.border-0
           イベントが作成されました
         = link_to "トップページへ戻る", root_path
-        = link_to "イベントページ", "/events/#{@event.token}"
+        = link_to "イベントページ", "/events/#{@event.id}/#{@event.token}"
 
 = render "./shared/footer"

--- a/app/views/events/create.html.haml
+++ b/app/views/events/create.html.haml
@@ -5,8 +5,16 @@
     .row
       .col-12.text-center
         .mx-auto.border-0
-          イベントが作成されました
-        = link_to "トップページへ戻る", root_path
+          イベントが作成されました。以下のURLを皆に知らせてあげましょう。以降、このURLページにて各自の出欠情報を入力してもらいます。
+
+        .mx-auto.border-0= "#{root_url(only_path: false)}#{@event.id}/#{@event.token}"
+
         = link_to "イベントページ", "/events/#{@event.id}/#{@event.token}"
+
+  .container.max-w.mb-2
+    .row
+      .col-12.text-center
+        .mx-auto.border-0
+        = link_to "トップページへ戻る", root_path
 
 = render "./shared/footer"

--- a/app/views/events/create.html.haml
+++ b/app/views/events/create.html.haml
@@ -7,5 +7,6 @@
         .mx-auto.border-0
           イベントが作成されました
         = link_to "トップページへ戻る", root_path
+        = link_to "イベントページ", "/events/#{@event.token}"
 
 = render "./shared/footer"

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -5,9 +5,9 @@
     .row
       - @events.each do |event|
         .col-md-6
-          = link_to event_path(event) do
-            .card.mx-auto.mb-2.border-0.event
-              =render "event", event: event
+          .card.mx-auto.mb-2.border-0.event
+            = link_to "", event_path(event)
+            = render "event", event: event
     .row
       .col-12.text-center
         = paginate @events

--- a/app/views/events/new.html.haml
+++ b/app/views/events/new.html.haml
@@ -3,4 +3,3 @@
   %H1.text-center.create-event__title 新規イベント
   = render "form"
 = render "./shared/footer"
-

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -10,15 +10,6 @@
             .author-command
               = link_to "イベントを編集する", edit_event_path(@event), class: "btn mb-2 accent-1st-color-btn author-command__edit"
               = link_to "イベントを削除する", "/events/#{@event.id}", method: :delete, class: "btn accent-1st-color-btn author-command__delete"
-    - if current_user
-      .row.mb-2
-        .col-6
-          .w-50.mx-auto
-            = link_to "参加", event_attend_statuses_path(@event, params: {attend: 1}), method: :post, class: "btn w-100 js-participation accent-1st-color-btn", remote: :true
-        .col-6
-          .w-50.mx-auto
-            = link_to "欠席", event_attend_statuses_path(@event, params: {attend: 2}), method: :post, class: "btn w-100 js-absence accent-2nd-color-btn", remote: :true
-
     .row.mb-2
       .col-sm-12
         %h5.text-center.main-color 参加者

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -8,7 +8,6 @@
       - else
         = "ログインはこちら⇨"
 
-
   .global-menu__trigger.js-toggle-menu
     .menu-button
       %span.menu-button__1st-bar
@@ -20,6 +19,8 @@
       %ul.global-menu__list
         - if current_user
           %li.global-menu__item= link_to "ログアウト", destroy_user_session_path, method: :delete
+          %li.global-menu__item= link_to "マイページ", user_path(current_user)
+          %li.global-menu__item= link_to "ユーザー情報編集", edit_user_registration_path(current_user)
           %li.global-menu__item= link_to "イベント作成", new_event_path
           %li.global-menu__item= link_to "グループ作成", new_group_path
         - else

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,0 +1,26 @@
+= render "./shared/header"
+
+%body.main
+  %H1.text-center.create-event__title= "#{current_user.name}のマイページ"
+  .container
+    .row
+      %p.mx-auto.create-event__title 作成したイベント
+    .row
+      - @created_events.each do |event|
+        .col-md-6
+          .card.mx-auto.mb-2.border-0.event
+            = link_to "", "/events/#{event.id}/#{event.token}"
+            = render "./events/event", event: event
+
+    .row
+      %p.mx-auto.create-event__title 出欠登録したイベント
+    .row
+      - @attendance_events.each do |event|
+        .col-md-6
+          .card.mx-auto.mb-2.border-0.event
+            = link_to "", "/events/#{event.id}/#{event.token}"
+            = render "./events/event", event: event
+            = attend?(event)
+
+
+= render "./shared/footer"

--- a/config/initializers/securerandom.rb
+++ b/config/initializers/securerandom.rb
@@ -1,0 +1,1 @@
+require "securerandom"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
   resources :groups, except: [:destroy] do
     resources :group_members, only: [:create]
   end
+  resources :users, only: [:show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,8 @@ Rails.application.routes.draw do
   root 'events#index'
   resources :events do
     resources :attend_statuses, only: [:create]
+    get '/:token' => 'attend_statuses#edit'
   end
-  get 'events/:token' => 'attend_statuses#edit'
-
   resources :groups, except: [:destroy] do
     resources :group_members, only: [:create]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   resources :events do
     resources :attend_statuses, only: [:create]
   end
+  get 'events/:token' => 'attend_statuses#edit'
+
   resources :groups, except: [:destroy] do
     resources :group_members, only: [:create]
   end

--- a/db/migrate/20190116131009_add_token_to_events.rb
+++ b/db/migrate/20190116131009_add_token_to_events.rb
@@ -1,0 +1,5 @@
+class AddTokenToEvents < ActiveRecord::Migration[5.0]
+  def change
+    add_column :events, :token, :string, unique: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190113030654) do
+ActiveRecord::Schema.define(version: 20190116131009) do
 
   create_table "attend_statuses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 20190113030654) do
     t.datetime "end_time"
     t.text     "comment",    limit: 65535
     t.integer  "user_id"
+    t.string   "token",                    null: false
   end
 
   create_table "group_members", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
#WHAT
出欠登録用に使用するURLをランダム文字列にする。
それに伴い、ユーザーマイページを作成する。

#WHY
URLを特定できないようにし、URLを知っているユーザーのみが出欠の登録を行えるようにするため。